### PR TITLE
Improve perceived synchronization of scroll views

### DIFF
--- a/src/components/sections/ProfileHorizontalScroll/index.tsx
+++ b/src/components/sections/ProfileHorizontalScroll/index.tsx
@@ -23,7 +23,7 @@ const ProfileHorizontalScroll = ({ profileData, scrollViewRef, scrollViewRefVert
       const position = event.nativeEvent.contentOffset.x / profileWidth
       const active = Math.round(position)
       setTheme({ ...theme, active })
-      scrollViewRefVertical.current?.scrollTo({ y: position * heightOfScrollView, animated: true })
+      scrollViewRefVertical.current?.scrollTo({ y: position * heightOfScrollView, animated: false })
     }
   }
 
@@ -34,7 +34,7 @@ const ProfileHorizontalScroll = ({ profileData, scrollViewRef, scrollViewRefVert
     if (userScrolling) {
       setUserScrolling(false)
 
-      scrollViewRefVertical.current?.scrollTo({ y: active * heightOfScrollView, animated: true })
+      scrollViewRefVertical.current?.scrollTo({ y: active * heightOfScrollView, animated: false })
     }
   }
   return (

--- a/src/components/sections/ProfileVerticalScroll/index.tsx
+++ b/src/components/sections/ProfileVerticalScroll/index.tsx
@@ -21,7 +21,7 @@ const ProfileVerticalScroll = ({ profileData, scrollViewRef, scrollViewRefHorizt
     if (userScrolling) {
       const position = event.nativeEvent.contentOffset.y / heightOfScrollView
       const active = Math.round(position)
-      scrollViewRefHoriztontal.current?.scrollTo({ x: position * profileWidth, animated: true })
+      scrollViewRefHoriztontal.current?.scrollTo({ x: position * profileWidth, animated: false })
       setTheme({ ...theme, active })
     }
   }
@@ -29,7 +29,7 @@ const ProfileVerticalScroll = ({ profileData, scrollViewRef, scrollViewRefHorizt
   const onScrollEnd = () => {
     if (userScrolling) {
       setUserScrolling(false)
-      scrollViewRefHoriztontal.current?.scrollTo({ x: active * profileWidth, animated: true })
+      scrollViewRefHoriztontal.current?.scrollTo({ x: active * profileWidth, animated: false })
     }
   }
 


### PR DESCRIPTION
When user taps on a profile, it is okay to use `animated: true`, but when you try to synchronise two scrollviews by using `onScroll`, it is better to use `animated: false`. Did you try?

I like the code you made. It would be even better if you wrapped callbacks with `useCallback`, and ideally factor out all of your logic related to synchronisation into a single hook used by both scrollviews. Can you do that for us?